### PR TITLE
Update icanhazip.com with ipify.org

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -78,7 +78,7 @@ var defaultProps = {
 
 var defaultPollingConfig = {
   enabled: inBrowser && unsupportedUserAgentsPattern.test(navigator.userAgent),
-  url: "https://ipv4.icanhazip.com/",
+  url: "https://api.ipify.org/?format=json",
   timeout: 5000,
   interval: 5000
 };

--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,7 @@ const defaultProps = {
 
 const defaultPollingConfig = {
   enabled: inBrowser && unsupportedUserAgentsPattern.test(navigator.userAgent),
-  url: "https://ipv4.icanhazip.com/",
+  url: "https://api.ipify.org/?format=json",
   timeout: 5000,
   interval: 5000
 };


### PR DESCRIPTION
Following up on #75, it seems this package is currently broken when using the default configuration due to ["module stopped working. canihazip.com domain has been taken over by someone else"](https://github.com/markogresak/canihazip/issues/2) on `canihazip.com` (which btw is now deprecated and showing a cake store or something).

With this PR I just replaced that domain with `ipify.org`, which is suggested by the original maintainer of `canihazip.com`.